### PR TITLE
Added cache policy property to client.

### DIFF
--- a/RestSharp/Http.Async.cs
+++ b/RestSharp/Http.Async.cs
@@ -461,6 +461,13 @@ namespace RestSharp
                 webRequest.Proxy = Proxy;
             }
 
+#if FRAMEWORK
+	        if (CachePolicy != null)
+	        {
+		        webRequest.CachePolicy = CachePolicy;
+	        }
+#endif
+
             if (FollowRedirects && MaxRedirects.HasValue)
             {
                 webRequest.MaximumAutomaticRedirections = MaxRedirects.Value;

--- a/RestSharp/Http.Async.cs
+++ b/RestSharp/Http.Async.cs
@@ -462,10 +462,10 @@ namespace RestSharp
             }
 
 #if FRAMEWORK
-	        if (CachePolicy != null)
-	        {
-		        webRequest.CachePolicy = CachePolicy;
-	        }
+            if (CachePolicy != null)
+            {
+                webRequest.CachePolicy = CachePolicy;
+            }
 #endif
 
             if (FollowRedirects && MaxRedirects.HasValue)

--- a/RestSharp/Http.Sync.cs
+++ b/RestSharp/Http.Sync.cs
@@ -298,10 +298,10 @@ namespace RestSharp
             }
 
 #if FRAMEWORK
-	        if (CachePolicy != null)
-	        {
-		        webRequest.CachePolicy = CachePolicy;
-	        }
+            if (CachePolicy != null)
+            {
+                webRequest.CachePolicy = CachePolicy;
+            }
 #endif
 
             webRequest.AllowAutoRedirect = FollowRedirects;

--- a/RestSharp/Http.Sync.cs
+++ b/RestSharp/Http.Sync.cs
@@ -297,6 +297,13 @@ namespace RestSharp
                 webRequest.Proxy = Proxy;
             }
 
+#if FRAMEWORK
+	        if (CachePolicy != null)
+	        {
+		        webRequest.CachePolicy = CachePolicy;
+	        }
+#endif
+
             webRequest.AllowAutoRedirect = FollowRedirects;
             if (FollowRedirects && MaxRedirects.HasValue)
             {

--- a/RestSharp/Http.cs
+++ b/RestSharp/Http.cs
@@ -26,6 +26,9 @@ using RestSharp.Extensions;
 #if WINDOWS_PHONE
 using RestSharp.Compression.ZLib;
 #endif
+#if FRAMEWORK
+using System.Net.Cache;
+#endif
 
 namespace RestSharp
 {
@@ -196,6 +199,13 @@ namespace RestSharp
         /// Proxy info to be sent with request
         /// </summary>
         public IWebProxy Proxy { get; set; }
+#endif
+
+#if FRAMEWORK
+		/// <summary>
+		/// Caching policy for requests created with this wrapper.
+		/// </summary>
+		public RequestCachePolicy CachePolicy { get; set; }
 #endif
 
         /// <summary>

--- a/RestSharp/Http.cs
+++ b/RestSharp/Http.cs
@@ -202,10 +202,10 @@ namespace RestSharp
 #endif
 
 #if FRAMEWORK
-		/// <summary>
-		/// Caching policy for requests created with this wrapper.
-		/// </summary>
-		public RequestCachePolicy CachePolicy { get; set; }
+        /// <summary>
+        /// Caching policy for requests created with this wrapper.
+        /// </summary>
+        public RequestCachePolicy CachePolicy { get; set; }
 #endif
 
         /// <summary>

--- a/RestSharp/IHttp.cs
+++ b/RestSharp/IHttp.cs
@@ -79,7 +79,7 @@ namespace RestSharp
         bool PreAuthenticate { get; set; }
 
 #if FRAMEWORK
-		RequestCachePolicy CachePolicy { get; set; }
+        RequestCachePolicy CachePolicy { get; set; }
 #endif
 
         /// <summary>

--- a/RestSharp/IHttp.cs
+++ b/RestSharp/IHttp.cs
@@ -21,6 +21,10 @@ using System.Net;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 
+#if FRAMEWORK
+using System.Net.Cache;
+#endif
+
 namespace RestSharp
 {
     public interface IHttp
@@ -73,6 +77,10 @@ namespace RestSharp
         string RequestContentType { get; set; }
 
         bool PreAuthenticate { get; set; }
+
+#if FRAMEWORK
+		RequestCachePolicy CachePolicy { get; set; }
+#endif
 
         /// <summary>
         /// An alternative to RequestBody, for when the caller already has the byte array.

--- a/RestSharp/IRestClient.cs
+++ b/RestSharp/IRestClient.cs
@@ -25,6 +25,9 @@ using RestSharp.Deserializers;
 using System.Threading;
 using System.Threading.Tasks;
 #endif
+#if FRAMEWORK
+using System.Net.Cache;
+#endif
 
 namespace RestSharp
 {
@@ -72,6 +75,8 @@ namespace RestSharp
         X509CertificateCollection ClientCertificates { get; set; }
 
         IWebProxy Proxy { get; set; }
+
+		RequestCachePolicy CachePolicy { get; set; }
 #endif
 
         bool FollowRedirects { get; set; }

--- a/RestSharp/IRestClient.cs
+++ b/RestSharp/IRestClient.cs
@@ -76,7 +76,7 @@ namespace RestSharp
 
         IWebProxy Proxy { get; set; }
 
-		RequestCachePolicy CachePolicy { get; set; }
+        RequestCachePolicy CachePolicy { get; set; }
 #endif
 
         bool FollowRedirects { get; set; }

--- a/RestSharp/RestClient.cs
+++ b/RestSharp/RestClient.cs
@@ -61,10 +61,10 @@ namespace RestSharp
         /// </summary>
         public IWebProxy Proxy { get; set; }
 
-		/// <summary>
-		/// The cache policy to use for requests initiated by this client instance.
-		/// </summary>
-		public RequestCachePolicy CachePolicy { get; set; }
+        /// <summary>
+        /// The cache policy to use for requests initiated by this client instance.
+        /// </summary>
+        public RequestCachePolicy CachePolicy { get; set; }
 #endif
 
         /// <summary>
@@ -410,7 +410,7 @@ namespace RestSharp
 
             http.MaxRedirects = MaxRedirects;
 
-	        http.CachePolicy = CachePolicy;
+            http.CachePolicy = CachePolicy;
 #endif
 
             if (request.Credentials != null)

--- a/RestSharp/RestClient.cs
+++ b/RestSharp/RestClient.cs
@@ -24,6 +24,10 @@ using System.Text;
 using RestSharp.Deserializers;
 using RestSharp.Extensions;
 
+#if FRAMEWORK
+using System.Net.Cache;
+#endif
+
 namespace RestSharp
 {
     /// <summary>
@@ -56,6 +60,11 @@ namespace RestSharp
         /// Passed on to underlying WebRequest if set.
         /// </summary>
         public IWebProxy Proxy { get; set; }
+
+		/// <summary>
+		/// The cache policy to use for requests initiated by this client instance.
+		/// </summary>
+		public RequestCachePolicy CachePolicy { get; set; }
 #endif
 
         /// <summary>
@@ -400,6 +409,8 @@ namespace RestSharp
             }
 
             http.MaxRedirects = MaxRedirects;
+
+	        http.CachePolicy = CachePolicy;
 #endif
 
             if (request.Credentials != null)


### PR DESCRIPTION
This is to address [issue #403](https://github.com/restsharp/RestSharp/pull/403) previously raised to allow access to the caching policy within the context of a specific RestClient.  It is based on the code produced for [issue #401](https://github.com/restsharp/RestSharp/issues/401), which was potentially breaking.  This change is more limited, as it does not change default behavior.
